### PR TITLE
Added SOCKS5 proxying directly to SAP Cloud Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,24 @@
 
 ## Why?
 
-You might ask why do I need this project? The answer is whenever you want to work with On Premise Destinations and you don't have a VPN connection which would allow you to connect directly.
+You might ask why do I need this project? The answer is whenever you want to work with on-premise destinations or a system connected through a Cloud Connector and you don't have a VPN connection which would allow you to connect directly.
 
 ## Limitations
 
-The authenticaiton of the SAP BTP Cloud Foundry subaccount must be configured to use SAP ID or SAP Identity Authentication. For SAP Identity Authenticaiton you must have the credentials of a local user.
+The authentication of the SAP BTP Cloud Foundry subaccount must be configured to use SAP ID or SAP Identity Authentication. For SAP Identity Authentication you must have the credentials of a local user.
 
 ## How does it work
 
 ![sap-cf-proxy Architecture](documentation/sap-cf-proxy.png)
 
-This proxy makes use of the possibility to connect via ssh into an app (sshenabler) that is running inside the SAP BTP Cloud Foundry environment. From there the so called connectivity proxy is reachable. This proxy is provided by an instance of the Connectivity Service. On your development computer you have to start two programs:
+This proxy makes use of the possibility to connect via ssh into an app (sshenabler) that is running inside the SAP BTP Cloud Foundry environment. From there the so-called connectivity proxy is reachable. This proxy is provided by an instance of the Connectivity Service. On your development computer you have to start two programs:
 
 - the script that establishes the ssh tunnel and forwards requests from the local port 20003 and 20004 to connectivityproxy.internal.cf.eu10.hana.ondemand.com:20003 / 20004
 - the reverse proxy that by default listens on port 5050 and acts as your local endpoint for calls that should be forwarded to the on premise system
 
 When your local app that you develop e.g. a CAP Application using an external service, a SAPUI5 App or a REST Client Script sends a request to the proxy, it will either use the username / password provided as an basic authentication header or via the environment variables USERNAME / PASSWORD and use that to authenticate on the XSUAA service using the password grant type. In return a JWT is retrieved. This token is sent in the backend request and is translated to the X.509 certificate used for principal propagation in the Cloud Connector. The local reverse proxy sends request for an on premise destination to local port that are forwarded via the ssh tunnel to the proxy in the BTP.
+
+When you want to directly connect to e.g. a database running on-premise (Sybase ASE, Postgres, HANA) then this repository provides a proxy that tunnels TCP requests through to the database.
 
 ## Prerequisites
 
@@ -37,13 +39,29 @@ npm run start:sshtunnel
 
 Remark: The start ssh tunnel is currently forwarding the requests to 'connectivityproxy.internal.cf.eu10.hana.ondemand.com:20003' if you are not in the cf-eu10 region, you have to change this configuration in the package.json file.
 
+### Forward HTTP requests (CAP, UI5)
+
 Go to the SAP BTP Cockpit and open the details of the deployed app _sshenabler_. Navigate there to the Environment Variables. Copy the content of the textbox _System Provided_ to a local file called _default-env.json_. Then run the following commands in another terminal window:
 
 ```
 npm start
 ```
 
-## Proxy Configuration
+### Forward TCP data (Database connection)
+
+Go to the SAP BTP Cockpit and open the details of the deployed app _sshenabler_. Navigate there to the Environment Variables. Copy the content of the textbox _System Provided_ to a local file called _default-env.json_ in the directory *socks-proxy*.
+
+Then run the following commands in another terminal window. Make sure to change ON_PREMISE_HOST and ON_PREMISE_PORT to values that you see in the Cloud Connector configuration.
+
+```
+cd socks-proxy
+mvn compile
+ON_PREMISE_HOST=hostnameOfOnPremiseSystem ON_PREMISE_PORT=portOfOnPremiseSystem VCAP_SERVICES=$(jq '.VCAP_SERVICES' default-env.json|jq -c .) mvn compile exec:java -Dexec.mainClass="StartSocksProxy"
+```
+
+Now you can open your preferred database tool or also your application that uses JDBC to connect and just point it to *localhost:5050*.
+
+## Proxy Configuration (valid for HTTP request forwarding)
 
 Following properties can be configured in a .env file in the root folder of the project.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -290,6 +290,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -298,6 +299,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
       "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dev": true,
       "requires": {
         "camelcase": "5.0.0",
         "chalk": "2.4.2",
@@ -309,6 +311,7 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -1351,7 +1354,8 @@
     "camelcase": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+      "dev": true
     },
     "chalk": {
       "version": "4.1.2",
@@ -1452,7 +1456,8 @@
     "colorette": {
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+      "dev": true
     },
     "colors": {
       "version": "1.4.0",
@@ -1544,7 +1549,8 @@
     "dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true
     },
     "debug": {
       "version": "2.6.9",
@@ -1694,7 +1700,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -1721,7 +1728,8 @@
     "fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
     },
     "fastify-warning": {
       "version": "0.2.0",
@@ -1837,7 +1845,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -2120,7 +2129,8 @@
     "joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -2197,7 +2207,8 @@
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -2338,7 +2349,8 @@
     "mri": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
-      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -2591,6 +2603,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-7.2.0.tgz",
       "integrity": "sha512-pkZhaF1JiyQt4BRqkLANYWuZTxavmuXh3OHsb8goeQasTFgNdzOECXkZWyPYrA0YMRa8zKoVsCzeYz9lI2NYwA==",
+      "dev": true,
       "requires": {
         "args": "^5.0.1",
         "colorette": "^2.0.7",
@@ -2769,6 +2782,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -2892,7 +2906,8 @@
     "rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -2936,7 +2951,8 @@
     "secure-json-parse": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
-      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
+      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==",
+      "dev": true
     },
     "semver": {
       "version": "5.7.1",
@@ -3141,12 +3157,14 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/socks-proxy/pom.xml
+++ b/socks-proxy/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.1</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>sap-cf-socks-proxy</groupId>
+    <artifactId>socks-proxy</artifactId>
+    <version>0.0.1</version>
+    <name>socks-proxy</name>
+    <properties>
+        <java.version>8</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>net.sourceforge.jtds</groupId>
+            <artifactId>jtds</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-cloudfoundry-connector -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-cloudfoundry-connector</artifactId>
+            <version>2.0.9.RELEASE</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-spring-service-connector -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-spring-service-connector</artifactId>
+            <version>2.0.9.RELEASE</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20210307</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/socks-proxy/socks-proxy.iml
+++ b/socks-proxy/socks-proxy.iml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="web" name="Web">
+      <configuration>
+        <webroots />
+      </configuration>
+    </facet>
+    <facet type="Spring" name="Spring">
+      <configuration />
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: net.sourceforge.jtds:jtds:1.3.1" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-web:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-autoconfigure:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-logging:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: ch.qos.logback:logback-classic:1.2.11" level="project" />
+    <orderEntry type="library" name="Maven: ch.qos.logback:logback-core:1.2.11" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-to-slf4j:2.17.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.17.2" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:jul-to-slf4j:1.7.36" level="project" />
+    <orderEntry type="library" name="Maven: jakarta.annotation:jakarta.annotation-api:1.3.5" level="project" />
+    <orderEntry type="library" name="Maven: org.yaml:snakeyaml:1.30" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-json:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.3" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.3" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-tomcat:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.tomcat.embed:tomcat-embed-core:9.0.64" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.tomcat.embed:tomcat-embed-el:9.0.64" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.tomcat.embed:tomcat-embed-websocket:9.0.64" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-web:5.3.21" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-beans:5.3.21" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-webmvc:5.3.21" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-aop:5.3.21" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-expression:5.3.21" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-starter-test:2.7.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-test:2.7.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-test-autoconfigure:2.7.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.jayway.jsonpath:json-path:2.7.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.minidev:json-smart:2.4.8" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.minidev:accessors-smart:2.4.8" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.ow2.asm:asm:9.1" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.36" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: jakarta.xml.bind:jakarta.xml.bind-api:2.3.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: jakarta.activation:jakarta.activation-api:1.2.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.assertj:assertj-core:3.22.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest:2.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter:5.8.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-api:5.8.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.opentest4j:opentest4j:1.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-commons:1.8.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.1.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-params:5.8.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-engine:5.8.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-engine:1.8.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:4.5.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy:1.12.11" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy-agent:1.12.11" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:3.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-junit-jupiter:4.5.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.skyscreamer:jsonassert:1.5.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.vaadin.external.google:android-json:0.0.20131108.vaadin1" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-core:5.3.21" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-jcl:5.3.21" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.springframework:spring-test:5.3.21" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.xmlunit:xmlunit-core:2.9.0" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.cloud:spring-cloud-cloudfoundry-connector:2.0.9.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.cloud:spring-cloud-connectors-core:2.0.9.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.13.3" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.13.3" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.13.3" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.cloud:spring-cloud-spring-service-connector:2.0.9.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-context:5.3.21" level="project" />
+    <orderEntry type="library" name="Maven: org.json:json:20210307" level="project" />
+  </component>
+</module>

--- a/socks-proxy/src/main/java/ConnectivitySocks5ProxySocket.java
+++ b/socks-proxy/src/main/java/ConnectivitySocks5ProxySocket.java
@@ -1,0 +1,251 @@
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+ 
+public class ConnectivitySocks5ProxySocket extends Socket {
+
+    private static final byte SOCKS5_VERSION = 0x05;
+    private static final byte SOCKS5_JWT_AUTHENTICATION_METHOD = (byte) 0x80;
+    private static final byte SOCKS5_JWT_AUTHENTICATION_METHOD_VERSION = 0x01;
+    private static final byte SOCKS5_COMMAND_CONNECT_BYTE = 0x01;
+    private static final byte SOCKS5_COMMAND_REQUEST_RESERVED_BYTE = 0x00;
+    private static final byte SOCKS5_COMMAND_ADDRESS_TYPE_IPv4_BYTE = 0x01;
+    private static final byte SOCKS5_COMMAND_ADDRESS_TYPE_DOMAIN_BYTE = 0x03;
+    private static final byte SOCKS5_AUTHENTICATION_METHODS_COUNT = 0x01;
+    private static final int SOCKS5_JWT_AUTHENTICATION_METHOD_UNSIGNED_VALUE = 0x80 & 0xFF;
+    private static final byte SOCKS5_AUTHENTICATION_SUCCESS_BYTE = 0x00;
+ 
+    private static final String SOCKS5_PROXY_HOST_PROPERTY = "onpremise_proxy_host";
+    private static final String SOCKS5_PROXY_PORT_PROPERTY = "onpremise_socks5_proxy_port";
+ 
+    private final String jwtToken;
+    private final String sccLocationId;
+    private final boolean useSSHTunnel;
+ 
+    public ConnectivitySocks5ProxySocket(String jwtToken4ConnectivityService, String sccLocationId, boolean useSSHTunnel) {
+        this.jwtToken = jwtToken4ConnectivityService;
+        this.sccLocationId = sccLocationId != null ? Base64.getEncoder().encodeToString(sccLocationId.getBytes()) : "";
+        this.useSSHTunnel = useSSHTunnel;
+    }
+ 
+    protected InetSocketAddress getProxyAddress() {
+        try {
+            if (!useSSHTunnel) {
+                JSONObject credentials = extractEnvironmentCredentials();
+                String proxyHost = credentials.getString(SOCKS5_PROXY_HOST_PROPERTY);
+                int proxyPort = Integer.parseInt(credentials.getString(SOCKS5_PROXY_PORT_PROPERTY));
+                return new InetSocketAddress(proxyHost, proxyPort);
+            } else {
+                return new InetSocketAddress("localhost", 20004);
+            }
+        } catch (JSONException ex) {
+            throw new IllegalStateException("Unable to extract the SOCKS5 proxy host and port", ex);
+        }
+    }
+ 
+    private JSONObject extractEnvironmentCredentials() throws JSONException {
+        JSONObject jsonObj = new JSONObject(System.getenv("VCAP_SERVICES"));
+        JSONArray jsonArr = jsonObj.getJSONArray("connectivity");
+        return jsonArr.getJSONObject(0).getJSONObject("credentials");
+    }
+ 
+    @Override
+    public void connect(SocketAddress endpoint, int timeout) throws IOException {
+        super.connect(getProxyAddress(), timeout);
+        OutputStream outputStream = getOutputStream();
+        executeSOCKS5InitialRequest(outputStream);
+        executeSOCKS5AuthenticationRequest(outputStream);
+        executeSOCKS5ConnectRequest(outputStream, (InetSocketAddress) endpoint);
+    }
+ 
+    private void executeSOCKS5InitialRequest(OutputStream outputStream) throws IOException {
+        byte[] initialRequest = createInitialSOCKS5Request();
+        outputStream.write(initialRequest);
+        assertServerInitialResponse();
+    }
+ 
+    private byte[] createInitialSOCKS5Request() throws IOException {
+        try (ByteArrayOutputStream byteArraysStream = new ByteArrayOutputStream()) {
+            byteArraysStream.write(SOCKS5_VERSION);
+            byteArraysStream.write(SOCKS5_AUTHENTICATION_METHODS_COUNT);
+            byteArraysStream.write(SOCKS5_JWT_AUTHENTICATION_METHOD);
+            return byteArraysStream.toByteArray();
+        }
+    }
+ 
+    private void assertServerInitialResponse() throws IOException {
+        InputStream inputStream = getInputStream();
+ 
+        int versionByte = inputStream.read();
+        if (SOCKS5_VERSION != versionByte) {
+            throw new SocketException(String.format("Unsupported SOCKS version - expected %s, but received %s", SOCKS5_VERSION, versionByte));
+        }
+ 
+        int authenticationMethodValue = inputStream.read();
+        if (SOCKS5_JWT_AUTHENTICATION_METHOD_UNSIGNED_VALUE != authenticationMethodValue) {
+            throw new SocketException(String.format("Unsupported authentication method value - expected %s, but received %s",
+                    SOCKS5_JWT_AUTHENTICATION_METHOD_UNSIGNED_VALUE, authenticationMethodValue));
+        }
+    }
+ 
+    private void executeSOCKS5AuthenticationRequest(OutputStream outputStream) throws IOException {
+        byte[] authenticationRequest = createJWTAuthenticationRequest();
+        outputStream.write(authenticationRequest);
+ 
+        assertAuthenticationResponse();
+    }
+ 
+    private byte[] createJWTAuthenticationRequest() throws IOException {
+        try (ByteArrayOutputStream byteArraysStream = new ByteArrayOutputStream()) {
+            byteArraysStream.write(SOCKS5_JWT_AUTHENTICATION_METHOD_VERSION);
+            byteArraysStream.write(ByteBuffer.allocate(4).putInt(jwtToken.getBytes().length).array());
+            byteArraysStream.write(jwtToken.getBytes());
+            byteArraysStream.write(ByteBuffer.allocate(1).put((byte) sccLocationId.getBytes().length).array());
+            byteArraysStream.write(sccLocationId.getBytes());
+            return byteArraysStream.toByteArray();
+        }
+    }
+ 
+    private void assertAuthenticationResponse() throws IOException {
+        InputStream inputStream = getInputStream();
+ 
+        int authenticationMethodVersion = inputStream.read();
+        if (SOCKS5_JWT_AUTHENTICATION_METHOD_VERSION != authenticationMethodVersion) {
+            throw new SocketException(String.format("Unsupported authentication method version - expected %s, but received %s",
+                    SOCKS5_JWT_AUTHENTICATION_METHOD_VERSION, authenticationMethodVersion));
+        }
+ 
+        int authenticationStatus = inputStream.read();
+        if (SOCKS5_AUTHENTICATION_SUCCESS_BYTE != authenticationStatus) {
+            throw new SocketException("Authentication failed!");
+        }
+    }
+ 
+    private void executeSOCKS5ConnectRequest(OutputStream outputStream, InetSocketAddress endpoint) throws IOException {
+        byte[] commandRequest = createConnectCommandRequest(endpoint);
+        outputStream.write(commandRequest);
+ 
+        assertConnectCommandResponse();
+    }
+ 
+    private byte[] createConnectCommandRequest(InetSocketAddress endpoint) throws IOException {
+        String host = endpoint.getHostName();
+        int port = endpoint.getPort();
+        try (ByteArrayOutputStream byteArraysStream = new ByteArrayOutputStream()) {
+            byteArraysStream.write(SOCKS5_VERSION);
+            byteArraysStream.write(SOCKS5_COMMAND_CONNECT_BYTE);
+            byteArraysStream.write(SOCKS5_COMMAND_REQUEST_RESERVED_BYTE);
+            byte[] hostToIPv4 = parseHostToIPv4(host);
+            if (hostToIPv4 != null) {
+                byteArraysStream.write(SOCKS5_COMMAND_ADDRESS_TYPE_IPv4_BYTE);
+                byteArraysStream.write(hostToIPv4);
+            } else {
+                byteArraysStream.write(SOCKS5_COMMAND_ADDRESS_TYPE_DOMAIN_BYTE);
+                byteArraysStream.write(ByteBuffer.allocate(1).put((byte) host.getBytes().length).array());
+                byteArraysStream.write(host.getBytes());
+            }
+            byteArraysStream.write(ByteBuffer.allocate(2).putShort((short) port).array());
+            return byteArraysStream.toByteArray();
+        }
+    }
+ 
+    private void assertConnectCommandResponse() throws IOException {
+        InputStream inputStream = getInputStream();
+ 
+        int versionByte = inputStream.read();
+        if (SOCKS5_VERSION != versionByte) {
+            throw new SocketException(String.format("Unsupported SOCKS version - expected %s, but received %s", SOCKS5_VERSION, versionByte));
+        }
+ 
+        int connectStatusByte = inputStream.read();
+        assertConnectStatus(connectStatusByte);
+ 
+        readRemainingCommandResponseBytes(inputStream);
+    }
+ 
+    private void assertConnectStatus(int commandConnectStatus) throws IOException {
+        if (commandConnectStatus == 0) {
+            return;
+        }
+ 
+        String commandConnectStatusTranslation;
+        switch (commandConnectStatus) {
+            case 1:
+                commandConnectStatusTranslation = "FAILURE";
+                break;
+            case 2:
+                commandConnectStatusTranslation = "FORBIDDEN";
+                break;
+            case 3:
+                commandConnectStatusTranslation = "NETWORK_UNREACHABLE";
+                break;
+            case 4:
+                commandConnectStatusTranslation = "HOST_UNREACHABLE";
+                break;
+            case 5:
+                commandConnectStatusTranslation = "CONNECTION_REFUSED";
+                break;
+            case 6:
+                commandConnectStatusTranslation = "TTL_EXPIRED";
+                break;
+            case 7:
+                commandConnectStatusTranslation = "COMMAND_UNSUPPORTED";
+                break;
+            case 8:
+                commandConnectStatusTranslation = "ADDRESS_UNSUPPORTED";
+                break;
+            default:
+                commandConnectStatusTranslation = "UNKNOWN";
+                break;
+        }
+        throw new SocketException("SOCKS5 command failed with status: " + commandConnectStatusTranslation);
+    }
+ 
+    private byte[] parseHostToIPv4(String hostName) {
+        byte[] parsedHostName = null;
+        String[] virtualHostOctets = hostName.split("\\.", -1);
+        int octetsCount = virtualHostOctets.length;
+        if (octetsCount == 4) {
+            try {
+                byte[] ipOctets = new byte[octetsCount];
+                for (int i = 0; i < octetsCount; i++) {
+                    int currentOctet = Integer.parseInt(virtualHostOctets[i]);
+                    if ((currentOctet < 0) || (currentOctet > 255)) {
+                        throw new IllegalArgumentException(String.format("Provided octet %s is not in the range of [0-255]", currentOctet));
+                    }
+                    ipOctets[i] = (byte) currentOctet;
+                }
+                parsedHostName = ipOctets;
+            } catch (IllegalArgumentException ex) {
+                return null;
+            }
+        }
+ 
+        return parsedHostName;
+    }
+ 
+    private void readRemainingCommandResponseBytes(InputStream inputStream) throws IOException {
+        inputStream.read(); // skipping over SOCKS5 reserved byte
+        int addressTypeByte = inputStream.read();
+        if (SOCKS5_COMMAND_ADDRESS_TYPE_IPv4_BYTE == addressTypeByte) {
+            for (int i = 0; i < 6; i++) {
+                inputStream.read();
+            }
+        } else if (SOCKS5_COMMAND_ADDRESS_TYPE_DOMAIN_BYTE == addressTypeByte) {
+            int domainNameLength = inputStream.read();
+            int portBytes = 2;
+            inputStream.read(new byte[domainNameLength + portBytes], 0, domainNameLength + portBytes);
+        }
+    }
+}

--- a/socks-proxy/src/main/java/DBSocketFactory.java
+++ b/socks-proxy/src/main/java/DBSocketFactory.java
@@ -1,0 +1,70 @@
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestTemplate;
+
+import javax.net.SocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+public class DBSocketFactory extends SocketFactory {
+
+	private final boolean useSSHTunnel;
+	private final String locationId;
+
+	public DBSocketFactory(String cloudConnectorLocationId, boolean useSSHTunnel) {
+		super();
+		this.useSSHTunnel = useSSHTunnel;
+		this.locationId = cloudConnectorLocationId;
+	}
+	
+	@Override
+	public Socket createSocket() throws IOException {
+		JSONObject credentials = extractEnvironmentCredentials();
+		String client_id = credentials.getString("clientid");
+		String client_secret = credentials.getString("clientsecret");
+		String tokenUrl = credentials.getString("url") + "/oauth/token?grant_type=client_credentials";
+		
+		RestTemplate template = new RestTemplate();
+		HttpHeaders headers = new HttpHeaders();
+		headers.setBasicAuth(client_id, client_secret);
+		HttpEntity<String> entity =  new HttpEntity<String>(headers);
+		
+		String response = template.exchange(tokenUrl,HttpMethod.GET, entity, String.class).getBody();
+		
+		JSONObject obj = new JSONObject(response);
+		return new ConnectivitySocks5ProxySocket(obj.getString("access_token"), locationId, useSSHTunnel);
+	}
+
+	@Override
+	public Socket createSocket(String arg0, int arg1) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Socket createSocket(InetAddress arg0, int arg1) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Socket createSocket(String arg0, int arg1, InetAddress arg2, int arg3) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Socket createSocket(InetAddress arg0, int arg1, InetAddress arg2, int arg3) {
+		throw new UnsupportedOperationException();
+	}
+
+	
+	private JSONObject extractEnvironmentCredentials() throws JSONException {
+        JSONObject jsonObj = new JSONObject(System.getenv("VCAP_SERVICES"));
+        JSONArray jsonArr = jsonObj.getJSONArray("connectivity");
+        return jsonArr.getJSONObject(0).getJSONObject("credentials");
+    }
+	
+}

--- a/socks-proxy/src/main/java/ProxyServer.java
+++ b/socks-proxy/src/main/java/ProxyServer.java
@@ -1,0 +1,87 @@
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.logging.Logger;
+
+public class ProxyServer {
+    private static final Logger LOGGER = Logger.getLogger(ProxyServer.class.getName());
+
+    private final ServerSocket serverSocket;
+    private final String hostname;
+    private final int port;
+    private final String cloudConnectorLocationId;
+    private final boolean useSSHTunnel;
+
+    public ProxyServer(int port, String hostnameToReach, int portToReach, String cloudConnectorLocationId, boolean useSSHTunnel) throws IOException {
+        this.serverSocket = new ServerSocket(port);
+        this.hostname = hostnameToReach;
+        this.port = portToReach;
+        this.cloudConnectorLocationId = cloudConnectorLocationId;
+        this.useSSHTunnel = useSSHTunnel;
+        LOGGER.info("Initialized SOCKS5 proxy server listening on 127.0.0.1:" + port + " " + (useSSHTunnel ?
+                "by using the SSH tunnel on localhost:20004": "by not using the SSH tunnel"));
+    }
+
+    public void run() throws IOException {
+        final byte[] request = new byte[1024];
+        byte[] reply = new byte[4096];
+
+        //noinspection InfiniteLoopStatement
+        while (true) {
+            Socket client;
+            try {
+                client = serverSocket.accept();
+                try (Socket socketToProxy = new DBSocketFactory(cloudConnectorLocationId, useSSHTunnel).createSocket()) {
+                    socketToProxy.connect(InetSocketAddress.createUnresolved(hostname, port));
+
+                    final InputStream streamFromServer = socketToProxy.getInputStream();
+                    final OutputStream streamToServer = socketToProxy.getOutputStream();
+
+                    final InputStream streamFromClient = client.getInputStream();
+                    final OutputStream streamToClient = client.getOutputStream();
+
+                    final Socket currentClient = client;
+                    Thread t = new Thread(() -> {
+                        int bytesRead;
+                        try {
+                            while (!currentClient.isClosed() && (bytesRead = streamFromClient.read(request)) != -1) {
+                                streamToServer.write(request, 0, bytesRead);
+                                streamToServer.flush();
+                            }
+                        } catch (IOException e) {
+                            LOGGER.throwing("ProxyServer", "run", e);
+                        }
+                    });
+
+                    t.start();
+
+                    int bytesRead;
+                    try {
+                        while ((bytesRead = streamFromServer.read(reply)) != -1) {
+                            streamToClient.write(reply, 0, bytesRead);
+                            streamToClient.flush();
+                        }
+                    } catch (IOException e) {
+                        LOGGER.throwing("ProxyServer", "run", e);
+                    }
+
+                    streamToClient.close();
+                } catch (IOException e) {
+                    LOGGER.throwing("ProxyServer", "run", e);
+                } finally {
+                    try {
+                        if (client != null)
+                            client.close();
+                    } catch (IOException e) {
+                        LOGGER.throwing("ProxyServer", "run", e);
+                    }
+                }
+            } catch (IOException e) {
+                LOGGER.throwing("ProxyServer", "run", e);
+            }
+        }
+    }
+}

--- a/socks-proxy/src/main/java/StartSocksProxy.java
+++ b/socks-proxy/src/main/java/StartSocksProxy.java
@@ -1,0 +1,24 @@
+import java.io.IOException;
+import java.util.logging.Logger;
+
+public class StartSocksProxy {
+    static Logger LOGGER = Logger.getLogger(StartSocksProxy.class.getName());
+
+    public static void main(String[] args) throws IOException {
+        if (System.getenv("ON_PREMISE_HOST") != null && System.getenv("ON_PREMISE_PORT") != null) {
+            String cloudConnectorLocationId = System.getenv("CLOUD_CONNECTOR_LOCATION_ID");
+            String useSSHTunnelAsString = System.getenv("USE_SSH_TUNNEL");
+            boolean useSSHTunnel = true;
+            if (useSSHTunnelAsString != null) {
+                useSSHTunnel = Boolean.parseBoolean(useSSHTunnelAsString);
+            }
+            LOGGER.info("Starting up local SOCKS5 proxy to " + System.getenv("ON_PREMISE_HOST") + ":" +
+                    System.getenv("ON_PREMISE_HOST"));
+            ProxyServer proxy = new ProxyServer(5050, System.getenv("ON_PREMISE_HOST"),
+                    Integer.parseInt(System.getenv("ON_PREMISE_PORT")), cloudConnectorLocationId, useSSHTunnel);
+            proxy.run();
+        } else {
+            LOGGER.severe("Could not find ON_PREMISE_HOST and/or ON_PREMISE_PORT defined in any valid way");
+        }
+    }
+}

--- a/socks-proxy/start-proxy.sh
+++ b/socks-proxy/start-proxy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export $(grep -v '^#' .env | xargs)
+VCAP_SERVICES=$(jq '.VCAP_SERVICES' default-env.json|jq -c .) mvn compile exec:java -Dexec.mainClass="StartSocksProxy" 


### PR DESCRIPTION
The current implementation does not work well with SOCKS5 TCP proxying directly to a SAP Cloud Connector. So I added this functionality as a separate Java application. 

Tested with a HANA and Sybase ASE. Both are on-premise and connected through a Cloud Connector to a BTP subaccount. I start the ssh tunnel, then the Java application and then I can direct my SQL editor to connect to the proxy-proxy-proxy thing.